### PR TITLE
`testcase` and `testsuite` may occur 0 times

### DIFF
--- a/src/junit.ts
+++ b/src/junit.ts
@@ -23,11 +23,11 @@ export const parseXML = (s: string): TestResult => {
 }
 
 export const flattenTestCases = (xml: TestResult): TestCase[] => {
-  if (xml.testsuites) {
-    return xml.testsuites.testsuite.flatMap((testSuite) => testSuite.testcase)
+  if (xml.testsuites && xml.testsuites.testsuite) {
+    return xml.testsuites.testsuite.flatMap((testSuite) => testSuite.testcase ?? [])
   }
   if (xml.testsuite) {
-    return xml.testsuite.testcase
+    return xml.testsuite.testcase ?? []
   }
   return []
 }
@@ -50,30 +50,36 @@ function assertTestResult(x: unknown): asserts x is TestResult {
 }
 
 type TestSuites = {
-  testsuite: TestSuite[]
+  // <testsuites> has 0 or more <testsuite>.
+  // https://llg.cubic.org/docs/junit/
+  testsuite?: TestSuite[]
 }
 
 function assertTestSuites(x: unknown): asserts x is TestSuites {
   assert(typeof x === 'object')
   assert(x != null)
-  assert('testsuite' in x)
-  assert(Array.isArray(x.testsuite))
-  for (const testsuite of x.testsuite) {
-    assertTestSuite(testsuite)
+  if ('testsuite' in x) {
+    assert(Array.isArray(x.testsuite))
+    for (const testsuite of x.testsuite) {
+      assertTestSuite(testsuite)
+    }
   }
 }
 
 type TestSuite = {
-  testcase: TestCase[]
+  // <testsuite> has 0 or more <testcase>.
+  // https://llg.cubic.org/docs/junit/
+  testcase?: TestCase[]
 }
 
 function assertTestSuite(x: unknown): asserts x is TestSuite {
   assert(typeof x === 'object')
   assert(x != null)
-  assert('testcase' in x)
-  assert(Array.isArray(x.testcase))
-  for (const testcase of x.testcase) {
-    assertTestCase(testcase)
+  if ('testcase' in x) {
+    assert(typeof x.testcase === 'undefined' || Array.isArray(x.testcase))
+    for (const testcase of (x.testcase ?? [])) {
+      assertTestCase(testcase)
+    }
   }
 }
 

--- a/src/junit.ts
+++ b/src/junit.ts
@@ -77,7 +77,7 @@ function assertTestSuite(x: unknown): asserts x is TestSuite {
   assert(x != null)
   if ('testcase' in x) {
     assert(typeof x.testcase === 'undefined' || Array.isArray(x.testcase))
-    for (const testcase of (x.testcase ?? [])) {
+    for (const testcase of x.testcase ?? []) {
       assertTestCase(testcase)
     }
   }

--- a/tests/__snapshots__/junit.test.ts.snap
+++ b/tests/__snapshots__/junit.test.ts.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty-testsuite.xml flattenTestCases 1`] = `[]`;
+
+exports[`empty-testsuite.xml parseXML 1`] = `
+{
+  "?xml": {
+    "@_encoding": "UTF-8",
+    "@_version": 1,
+  },
+  "testsuites": {
+    "@_errors": 0,
+    "@_failures": 0,
+    "@_name": "empty test suite",
+    "@_tests": 1,
+    "@_time": 0.865,
+    "testsuite": [
+      {
+        "@_errors": 0,
+        "@_failures": 0,
+        "@_name": "undefined",
+        "@_skipped": 0,
+        "@_tests": 1,
+        "@_time": 0.807,
+        "@_timestamp": "2023-08-04T12:22:11",
+      },
+    ],
+  },
+}
+`;
+
+exports[`empty-testsuites.xml flattenTestCases 1`] = `[]`;
+
+exports[`empty-testsuites.xml parseXML 1`] = `
+{
+  "?xml": {
+    "@_encoding": "UTF-8",
+    "@_version": 1,
+  },
+  "testsuites": {
+    "@_errors": 0,
+    "@_failures": 0,
+    "@_name": "empty testsuites",
+    "@_tests": 1,
+    "@_time": 0.865,
+  },
+}
+`;
+
 exports[`jest.xml flattenTestCases 1`] = `
 [
   {

--- a/tests/empty-testsuite.xml
+++ b/tests/empty-testsuite.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="empty test suite" tests="1" failures="0" errors="0" time="0.865">
+  <testsuite name="undefined" errors="0" failures="0" skipped="0" timestamp="2023-08-04T12:22:11" time="0.807" tests="1" />
+</testsuites>

--- a/tests/empty-testsuites.xml
+++ b/tests/empty-testsuites.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="empty testsuites" tests="1" failures="0" errors="0" time="0.865" />

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -2,6 +2,45 @@ import * as fs from 'fs/promises'
 import { assertTestCase, flattenTestCases, parseXML } from '../src/junit'
 import { join } from 'path'
 
+describe('empty-testsuite.xml', () => {
+  const fixturePath = join(__dirname, 'empty-testsuite.xml')
+
+  test('parseXML', async () => {
+    const xml = parseXML(await fs.readFile(fixturePath, 'utf-8'))
+    expect(xml).toBeTruthy()
+    expect(xml).toMatchSnapshot()
+  })
+
+  test('flattenTestCases', async () => {
+    const xml = parseXML(await fs.readFile(fixturePath, 'utf-8'))
+    const testCases = flattenTestCases(xml)
+    for (const testCase of testCases) {
+      assertTestCase(testCase)
+    }
+    expect(testCases).toMatchSnapshot()
+  })
+})
+
+describe('empty-testsuites.xml', () => {
+  const fixturePath = join(__dirname, 'empty-testsuites.xml')
+
+  test('parseXML', async () => {
+    const xml = parseXML(await fs.readFile(fixturePath, 'utf-8'))
+    expect(xml).toBeTruthy()
+    expect(xml).toMatchSnapshot()
+  })
+
+  test('flattenTestCases', async () => {
+    const xml = parseXML(await fs.readFile(fixturePath, 'utf-8'))
+    const testCases = flattenTestCases(xml)
+    for (const testCase of testCases) {
+      assertTestCase(testCase)
+    }
+    expect(testCases).toMatchSnapshot()
+  })
+})
+
+
 describe('rspec.xml', () => {
   const fixturePath = join(__dirname, 'rspec.xml')
 

--- a/tests/junit.test.ts
+++ b/tests/junit.test.ts
@@ -40,7 +40,6 @@ describe('empty-testsuites.xml', () => {
   })
 })
 
-
 describe('rspec.xml', () => {
   const fixturePath = join(__dirname, 'rspec.xml')
 


### PR DESCRIPTION
This will fix https://github.com/quipper/send-ci-result-to-bigquery-action/issues/98

https://llg.cubic.org/docs/junit/

```xml
    <xs:element name="testsuite">
        <xs:complexType>
            <xs:choice minOccurs="0" maxOccurs="unbounded">
                <xs:element ref="testsuite"/>
                <xs:element ref="properties"/>
                <xs:element ref="testcase"/>  <!-- THIS -->
                <xs:element ref="system-out"/>
                <xs:element ref="system-err"/>
            </xs:choice>
            <xs:attribute name="name" type="xs:string" use="required"/>
            <xs:attribute name="tests" type="xs:string" use="required"/>
            <xs:attribute name="failures" type="xs:string" use="required"/>
            <xs:attribute name="errors" type="xs:string" use="required"/>
            <xs:attribute name="group" type="xs:string" />
            <xs:attribute name="time" type="SUREFIRE_TIME"/>
            <xs:attribute name="skipped" type="xs:string" />
            <xs:attribute name="timestamp" type="xs:string" />
            <xs:attribute name="hostname" type="xs:string" />
            <xs:attribute name="id" type="xs:string" />
            <xs:attribute name="package" type="xs:string" />
            <xs:attribute name="file" type="xs:string"/>
            <xs:attribute name="log" type="xs:string"/>
            <xs:attribute name="url" type="xs:string"/>
            <xs:attribute name="version" type="xs:string"/>
        </xs:complexType>
    </xs:element>
```

```xml
    <xs:element name="testsuites">
        <xs:complexType>
            <xs:sequence>
                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded" />   <!-- THIS -->
            </xs:sequence>
            <xs:attribute name="name" type="xs:string" />
            <xs:attribute name="time" type="SUREFIRE_TIME"/>
            <xs:attribute name="tests" type="xs:string" />
            <xs:attribute name="failures" type="xs:string" />
            <xs:attribute name="errors" type="xs:string" />
        </xs:complexType>
    </xs:element>
```